### PR TITLE
Alesieur/2021 05 31/update formatters tests and regex

### DIFF
--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -78,6 +78,9 @@ def test_with_text_between_character_codes():
 
 def test_invalid_characters_should_fail():
     assert Formatter()._isValid('^*') == False
+    assert Formatter()._isValid('{100}') == False
+    assert Formatter()._isValid('{sldkfn}') == False
+    assert Formatter()._isValid('{}') == False
 
 def test_regex_finds_valid_character_codes():
     actual = Formatter()._getEmbeddedCharCodes('{24}{1}')

--- a/vestaboard/formatter.py
+++ b/vestaboard/formatter.py
@@ -18,13 +18,13 @@ class Formatter:
   @staticmethod
   def _isValid(inputString):
     inputString = inputString.lower()
-    test = "^(?:[A-Za-z0-9!@#$\(\)\-+&=;:'\"%,./?°\s ]*(?:\{[0-9]+\})*[A-Za-z0-9!@#$\(\)\-+&=;:'\"%,./?°\s ]*)*$"
+    test = r"^(?:[A-Za-z0-9!@#$\(\)\-+&=;:'\"%,./?°\s ]*(?:\{[0-9]+\})*[A-Za-z0-9!@#$\(\)\-+&=;:'\"%,./?°\s ]*)*$"
 
     return bool(re.match(test, inputString))
 
   @staticmethod
   def _getEmbeddedCharCodes(inputString):
-    test = "\{[0-9]+\}+"
+    test = r"\{[0-9]+\}+"
 
     return re.findall(test, inputString)
 

--- a/vestaboard/formatter.py
+++ b/vestaboard/formatter.py
@@ -18,7 +18,7 @@ class Formatter:
   @staticmethod
   def _isValid(inputString):
     inputString = inputString.lower()
-    test = r"^(?:[A-Za-z0-9!@#$\(\)\-+&=;:'\"%,./?°\s ]*(?:\{[0-9]+\})*[A-Za-z0-9!@#$\(\)\-+&=;:'\"%,./?°\s ]*)*$"
+    test = r"^(?:[A-Za-z0-9!@#$\(\)\-+&=;:'\"%,./?°\s]*(?:\{[0-9]+\})*[A-Za-z0-9!@#$\(\)\-+&=;:'\"%,./?°\s]*)*$"
 
     return bool(re.match(test, inputString))
 

--- a/vestaboard/formatter.py
+++ b/vestaboard/formatter.py
@@ -18,7 +18,7 @@ class Formatter:
   @staticmethod
   def _isValid(inputString):
     inputString = inputString.lower()
-    test = r"^(?:[A-Za-z0-9!@#$\(\)\-+&=;:'\"%,./?°\s]*(?:\{[0-9]+\})*[A-Za-z0-9!@#$\(\)\-+&=;:'\"%,./?°\s]*)*$"
+    test = r"^(?:[A-Za-z\d!@#$()\-+&=;:'\"%,./?°\s]|(?:\{\d{1,2}\}))*$"
 
     return bool(re.match(test, inputString))
 


### PR DESCRIPTION
Yo!
Just started looking at your code, and just saw that (unless I'm mistaken) the RegEx you used for to evaluate can be simplified a bit.
It could also be improved to directly reject any number that's not technically valid inside `{..}` but I believe you do that somewhere else too so not doing that just yet. I did ignore numbers w/ 3+ digits because we know these are not a thing.